### PR TITLE
Use generated functions for simpler multi-dimensional integration syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ vx=range(0,1,length=100)
 vy=range(0,2,length=200)
 vz=range(0,3,length=300)
 M=[x^2+y^2+z^2 for x=vx,y=vy,z=vz]
-@show trapz(vx,trapz(vy,trapz(vz,M)));
+@show trapz((vx,vy,vz), M);
 
 ```
 
-    trapz(vx, trapz(vy, trapz(vz, M))) = 28.00030370797026
+    trapz((vx, vy, vz), M) = 28.000303707970264
 
 
 # Benchmarks
 
 
 ```julia
-@benchmark trapz($vx,trapz($vy,trapz($vz,$M)))
+@benchmark trapz(($vx,$vy,$vz),$M)
 ```
 
 
@@ -52,7 +52,7 @@ M=[x^2+y^2+z^2 for x=vx,y=vy,z=vz]
 
 
 ```julia
-@benchmark trapz($vy,trapz($vz,$M))
+@benchmark trapz(($vy, $vz),$M)
 ```
 
 
@@ -100,7 +100,7 @@ This code is optimized in order to perform the integral the fastest over the las
 
 
 ```julia
-@benchmark trapz($vz,trapz($vy,trapz($vx,$M,1),1),1)
+@benchmark trapz(($vz,$vy,$vx),$M,(3,2,1))
 ```
 
 


### PR DESCRIPTION
This PR simplifies the multidimensional integration syntax without the loss of performance by using generated functions.

With this PR you can now do
```julia
julia> using BenchmarkTools, Trapz

julia> vx=range(0,1,length=100);

julia> vy=range(0,2,length=200);

julia> vz=range(0,3,length=300);

julia> M=[x^2+y^2+z^2 for x=vx,y=vy,z=vz];

julia> @show trapz((vx,vy,vz), M);
trapz((vx, vy, vz), M) = 28.000303707970264

julia> @benchmark trapz(($vx,$vy,$vz), $M)
BenchmarkTools.Trial:
  memory estimate:  347.31 KiB
  allocs estimate:  607
  --------------
  minimum time:     3.846 ms (0.00% GC)
  median time:      4.166 ms (0.00% GC)
  mean time:        4.425 ms (0.56% GC)
  maximum time:     8.370 ms (45.19% GC)
  --------------
  samples:          1130
  evals/sample:     1

julia> @benchmark trapz($vx,trapz($vy,trapz($vz,$M)))
BenchmarkTools.Trial:
  memory estimate:  347.31 KiB
  allocs estimate:  607
  --------------
  minimum time:     3.866 ms (0.00% GC)
  median time:      4.467 ms (0.00% GC)
  mean time:        4.688 ms (0.65% GC)
  maximum time:     10.269 ms (43.07% GC)
  --------------
  samples:          1066
  evals/sample:     1

jjulia> @benchmark trapz(($vz,$vy,$vx),$M,(3,2,1))
BenchmarkTools.Trial:
  memory estimate:  973.13 KiB
  allocs estimate:  617
  --------------
  minimum time:     21.974 ms (0.00% GC)
  median time:      23.271 ms (0.00% GC)
  mean time:        23.377 ms (0.30% GC)
  maximum time:     27.282 ms (13.70% GC)
  --------------
  samples:          214
  evals/sample:     1

julia> @benchmark trapz(($vy,$vx,$vz),$M,(2,1,3))
BenchmarkTools.Trial:
  memory estimate:  349.78 KiB
  allocs estimate:  617
  --------------
  minimum time:     7.774 ms (0.00% GC)
  median time:      8.001 ms (0.00% GC)
  mean time:        8.040 ms (0.39% GC)
  maximum time:     13.094 ms (38.39% GC)
  --------------
  samples:          622
  evals/sample:     1
```