### PR TITLE
Allow more flexible type promotion

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Trapz"
 uuid = "592b5752-818d-11e9-1e9a-2b8ca4a44cd1"
 authors = ["Francesco Alemanno <francescoalemanno710@gmail.com>"]
-version = "2.0.2"
+version = "2.0.3"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,8 @@ version = "2.0.2"
 julia = "1"
 
 [extras]
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Unitful"]

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -23,7 +23,8 @@ end
         @assert sy[axis]==N "Integration axis over `y` is incompatible with `x`. Make sure their length match!"
         @assert maximum(size(x))==N "`x` is not vector-like."
     end
-    res=zeros(promote_type(Tm,Tv),extrudeindex(sy,val_axis))
+    out_type = typeof(oneunit(Tm) * oneunit(Tv))
+    res=zeros(out_type,extrudeindex(sy,val_axis))
     @inline idx(I,j) = CartesianIndex(putindex(Tuple(I),val_axis,j))
     N <= 1 && return purge(res)
     @simd for ids in CartesianIndices(res)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Test
 using Trapz
+using Unitful
+
 @info "Started Package Testing"
 vx=range(0,1,length=5)
 vy=range(0,2,length=10)
@@ -69,4 +71,14 @@ end
         end
     end
     @test r≈res
+end
+
+# test whether units work, which requires proper type information to be
+# applied to the output arrays
+@testset "units" begin
+    x=(1:10)u"m"
+    y=range(-0.1, 10, length=length(x))u"J/m"
+    res = trapz(x, y)
+    @test unit(res) == u"J"
+    @test res ≈ 44.55u"J"
 end


### PR DESCRIPTION
- fix type promotion to be more flexible
- add Unitful unittests
- bump version 2.0.2 -> 2.0.3

This PR slightly alters the output type of `integrate` to be more flexible. Specifically, I wanted to get this working with `Unitful.jl` units. Previously, this would fail:
```julia
using Unitful, Trapz
x = (1:10)u"m"
y = range(-0.1, 10. length=10)u"J/m"
trapz(x, y)
```

would fail, because `promote_type(u"m", u"J/m")` would just become `Float64` (or similar). Now, by using `typeof(oneunit(u"m") * oneunit(u"J/m"))` the output type is appropriately calculated without sacrificing pretty much anything. To double check, I've benchmarked the before and after code:

```julia
using BenchmarkTools
function benchmark(N=100)
    x = range(0, 10, length=N)
    y = 0.5 .* x
    @btime trapz($x, $y)
end
```
**master branch**
```julia
julia> benchmark()
  625.793 ns (1 allocation: 96 bytes)
25.0
```
**this PR**
```julia
julia> benchmark()
  628.406 ns (1 allocation: 96 bytes)
25.0
```

I've added unit tests and bumped the patch version, so hopefully when this is merged it can be released quickly.
