### PR TITLE
Add support for missing

### DIFF
--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -24,6 +24,10 @@ end
         @assert maximum(size(x))==N "`x` is not vector-like."
     end
     out_type = typeof(oneunit(Tm) * oneunit(Tv))
+    if Missing <: Tv || Missing <: Tm
+        out_type = Union{Missing,out_type}
+    end
+    out_type
     res=zeros(out_type,extrudeindex(sy,val_axis))
     @inline idx(I,j) = CartesianIndex(putindex(Tuple(I),val_axis,j))
     N <= 1 && return purge(res)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,3 +82,11 @@ end
     @test unit(res) == u"J"
     @test res ≈ 44.55u"J"
 end
+
+@testset "missing" begin
+    x=1:10
+    y=vcat(1:2,missing,4:10)
+    @test ismissing(trapz(x, y))
+    @test ismissing(trapz(y, x))
+    @test ismissing(trapz(y, y))
+end


### PR DESCRIPTION
This makes `trapz` return `missing` when either the x or y data contain a value of `missing`. I have an old package that I am updating, and I believe Trapz.jl version 1 also worked this way. The behavior is consistent with how other functions (such as sum) operate on arrays with `missing`. 